### PR TITLE
Change `Bit` to be type alias

### DIFF
--- a/byteutils.go
+++ b/byteutils.go
@@ -42,7 +42,7 @@ func ChangeL(b *byte, index byte, bit Bit) {
 
 // ChangeR changes the nth bit from the left to the bit provided.
 func ChangeR(b *byte, index byte, bit Bit) {
-	if AsBool(bit) {
+	if BitAsBool(bit) {
 		SetR(b, index)
 	} else {
 		ClearR(b, index)
@@ -94,7 +94,7 @@ func BitAsBool(b Bit) bool {
 
 // Normalize forces a bit to be either Zero or One
 func normalize(b Bit) Bit {
-	if AsBool(b) {
+	if BitAsBool(b) {
 		return One
 	}
 	return Zero

--- a/byteutils_test.go
+++ b/byteutils_test.go
@@ -2,12 +2,12 @@ package byteutils
 
 import "testing"
 
-// TestAsBool checks that a bit is false when it is 0, true otherwise.
-func TestAsBool(t *testing.T) {
-	if AsBool(Zero) {
+// TestBitAsBool checks that a bit is false when it is 0, true otherwise.
+func TestBitAsBool(t *testing.T) {
+	if BitAsBool(Zero) {
 		t.Error("want Zero to be false")
 	}
-	if !AsBool(One) {
+	if !BitAsBool(One) {
 		t.Error("want One to be true")
 	}
 }


### PR DESCRIPTION
Instead of being its own type, this makes `Bit` a type alias of the built-in `byte` type.