### PR TITLE
Remove default case

### DIFF
--- a/endianness.go
+++ b/endianness.go
@@ -56,8 +56,6 @@ func (e Endian) iterateNumber(n interface{}, f ByteIteratorFunc) {
 	case uint32:
 		smallest, largest = e.byteRange(4)
 		value = v
-	default:
-		panic("unreachable")
 	}
 
 	if e == BigEndian {


### PR DESCRIPTION
Should never be reached since it is a private method, so doesn't need to exist or be tested.